### PR TITLE
Fix Table for Contrast React Bootstrap SidebarCTA Props

### DIFF
--- a/content/contrast/react/navigation/sidebar.mdx
+++ b/content/contrast/react/navigation/sidebar.mdx
@@ -558,5 +558,4 @@ The table below lists other prop options of the `CDBSidebarCTA` component.
 | :------------ | :-----: | ------: | :----------------------------------------------------------------------------: | -----------------------------------------------------------------------: |
 | image     | node  |         |                          Define Image for  the CTA component                              |                          `<CDBSidebarCTA image={<img src="" />} ... />` |
 | theme         | String  |   default |                           Changes default input tag                            |                                  `<CDBSidebarCTA theme="default" ... />` |
-
 | text         | String  |     div |                           Changes default input tag                            |                                  `<CDBSidebarSubMenu text="Welcome to your dashboard" ... />` |


### PR DESCRIPTION
There was an extra Line which caused the Table to show the last Line in it.